### PR TITLE
Fix null-pointer lexer crash

### DIFF
--- a/src/main/java/com/google/summit/SummitTool.kt
+++ b/src/main/java/com/google/summit/SummitTool.kt
@@ -48,7 +48,7 @@ object SummitTool {
 
     override fun syntaxError(
       recognizer: Recognizer<*, *>,
-      offendingSymbol: Any,
+      offendingSymbol: Any?,
       line: Int,
       charPositionInLine: Int,
       msg: String,


### PR DESCRIPTION
Allow `offendingSymbol` to be null.

b/236414037