### PR TITLE
Translate `static` anonymous initializers

### DIFF
--- a/src/main/java/com/google/summit/translation/Translate.kt
+++ b/src/main/java/com/google/summit/translation/Translate.kt
@@ -130,7 +130,7 @@ class Translate(val file: String, private val tokens: TokenStream) : ApexParserB
   }
 
   /** Exception for any unexpected translation errors. */
-  class TranslationException(val ctx: ParseTree, msg: String, cause: Throwable? = null) :
+  class TranslationException(val tree: ParseTree, msg: String, cause: Throwable? = null) :
     Exception(msg, cause)
 
   /** Translates the 'id' grammar rule and returns an AST [Identifier]. */

--- a/src/main/javatests/com/google/summit/testing/TranslateHelpers.kt
+++ b/src/main/javatests/com/google/summit/testing/TranslateHelpers.kt
@@ -87,7 +87,7 @@ object TranslateHelpers {
     try {
       return parseAndTranslateWithExceptions(input)
     } catch (e: Translate.TranslationException) {
-      assertWithMessage("Translation failed on %s because %s", e.ctx.text, e.message).fail()
+      assertWithMessage("Translation failed on %s because %s", e.tree.text, e.message).fail()
       // Exception to log-and-rethrow anti-pattern for syntactic purposes:
       // want to avoid returning optional type by exiting with exception.
       throw e
@@ -112,7 +112,7 @@ object TranslateHelpers {
       val root = parseAndTranslateWithExceptions(input)
       return findFirstNodeOfType<T>(root)
     } catch (e: Translate.TranslationException) {
-      assertWithMessage("Translation failed on %s because %s", e.ctx.text, e.message).fail()
+      assertWithMessage("Translation failed on %s because %s", e.tree.text, e.message).fail()
       // Exception to log-and-rethrow anti-pattern for syntactic purposes:
       // want to avoid returning optional type by exiting with exception.
       throw e

--- a/src/main/javatests/com/google/summit/translation/ModifierTest.kt
+++ b/src/main/javatests/com/google/summit/translation/ModifierTest.kt
@@ -18,11 +18,14 @@ package com.google.summit.translation
 
 import com.google.common.truth.Truth.assertThat
 import com.google.summit.ast.CompilationUnit
+import com.google.summit.ast.declaration.ClassDeclaration
 import com.google.summit.ast.modifier.AnnotationModifier
 import com.google.summit.ast.modifier.ElementValue
+import com.google.summit.ast.modifier.KeywordModifier
 import com.google.summit.ast.modifier.Modifier
 import com.google.summit.ast.traversal.DfsWalker
 import com.google.summit.testing.TranslateHelpers
+import kotlin.test.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -167,5 +170,32 @@ class ModifierTest {
     assertThat(annotationD.args).isEmpty()
 
     assertThat(annotationE.args).isEmpty()
+  }
+
+  @Test
+  fun anonymousInitialization_hasCorrectModifiers() {
+    val input =
+      """
+        class Test {
+          {
+            print('init');
+          }
+          static {
+            print('more init');
+          }
+        }
+        """
+    val classDecl = TranslateHelpers.parseAndFindFirstNodeOfType<ClassDeclaration>(input)
+
+    assertNotNull(classDecl)
+    assertThat(classDecl.methodDeclarations).hasSize(2)
+
+    val normalInitializer = classDecl.methodDeclarations.first()
+    assertThat(normalInitializer.modifiers).isEmpty()
+
+    val staticInitializer = classDecl.methodDeclarations.last()
+    assertThat(staticInitializer.modifiers).hasSize(1)
+    assertThat((staticInitializer.modifiers.first() as? KeywordModifier)?.keyword)
+      .isEqualTo(KeywordModifier.Keyword.STATIC)
   }
 }


### PR DESCRIPTION
- Add `STATIC` keyword modifier to `static` anonymous initializers
- Allow `TerminalNode`s to also be used as the `ctx` in a `TranslationException`
