### PR TITLE
Fix constructor declaration ambiguity

### DIFF
--- a/src/main/java/com/google/summit/ast/declaration/MethodDeclaration.kt
+++ b/src/main/java/com/google/summit/ast/declaration/MethodDeclaration.kt
@@ -34,6 +34,7 @@ import com.google.summit.ast.statement.CompoundStatement
  * @property returnType the static type of the returned value
  * @property parameterDeclarations a list of the static types of any formal parameters
  * @property body the method implementation, if defined
+ * @property isConstructor whether this is a constructor
  * @param loc the source location in the source file
  */
 class MethodDeclaration(
@@ -41,6 +42,7 @@ class MethodDeclaration(
   val returnType: TypeRef,
   val parameterDeclarations: List<ParameterDeclaration>,
   val body: CompoundStatement?,
+  val isConstructor: Boolean,
   loc: SourceLocation
 ) : Declaration(id, loc) {
   override fun getChildren(): List<Node> =

--- a/src/main/javatests/com/google/summit/testdata/mixednodes.json
+++ b/src/main/javatests/com/google/summit/testdata/mixednodes.json
@@ -85,6 +85,7 @@
               "arrayNesting": 0
             },
             "parameterDeclarations": [],
+            "isConstructor": false,
             "id": {
               "string": "foo",
               "sourceLocation": {
@@ -1165,6 +1166,7 @@
             "endColumn": 3
           }
         },
+        "isConstructor": false,
         "id": {
           "string": "foo",
           "sourceLocation": {
@@ -1259,6 +1261,7 @@
               "endColumn": 28
             }
           },
+          "isConstructor": false,
           "id": {
             "string": "get",
             "sourceLocation": {
@@ -1377,6 +1380,7 @@
               "endColumn": 29
             }
           },
+          "isConstructor": false,
           "id": {
             "string": "set",
             "sourceLocation": {

--- a/src/main/javatests/com/google/summit/translation/MethodDeclarationTest.kt
+++ b/src/main/javatests/com/google/summit/translation/MethodDeclarationTest.kt
@@ -18,6 +18,7 @@ package com.google.summit.translation
 
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
+import com.google.summit.ast.declaration.ClassDeclaration
 import com.google.summit.ast.declaration.MethodDeclaration
 import com.google.summit.ast.modifier.KeywordModifier
 import com.google.summit.testing.TranslateHelpers
@@ -90,5 +91,27 @@ class MethodDeclarationTest {
     assertWithMessage("Parameter should have 'final' modifier")
       .that((parameterModifier as? KeywordModifier)?.keyword)
       .isEqualTo(KeywordModifier.Keyword.FINAL)
+  }
+
+  @Test
+  fun constructors_areCorrectlyIdentified() {
+    val input =
+      """
+        class Test {
+          void Test() { }
+          Test() { }
+        }
+        """
+
+    val classDecl = TranslateHelpers.parseAndFindFirstNodeOfType<ClassDeclaration>(input)
+
+    assertNotNull(classDecl)
+    assertThat(classDecl.methodDeclarations).hasSize(2)
+
+    val methodDecl = classDecl.methodDeclarations.first()
+    assertThat(methodDecl.isConstructor).isFalse()
+
+    val constructorDecl = classDecl.methodDeclarations.last()
+    assertThat(constructorDecl.isConstructor).isTrue()
   }
 }


### PR DESCRIPTION
Constructor declarations are ambiguous with method declarations of the same name with return type `void`.

#### Example
Input:
```apex
class foo {
    void foo() { }
    foo() { }
}
```
AST:
```json
"methodDeclarations": [
  {
    "returnType": {
      "components": [],
      "arrayNesting": 0
    },
    "parameterDeclarations": [],
    "body": {
      "statements": [],
      "scoping": "SCOPE_BOUNDARY"
    },
    "id": {
      "string": "foo"
    },
    "modifiers": []
  },
  {
    "returnType": {
      "components": [],
      "arrayNesting": 0
    },
    "parameterDeclarations": [],
    "body": {
      "statements": [],
      "scoping": "SCOPE_BOUNDARY"
    },
    "id": {
      "string": "foo"
    },
    "modifiers": []
  }
]
```

#### Changes
- Add `isConstructor` property to `MethodDeclaration` to differentiate constructor declarations and method declarations during translation.
- Add unit tests.