### PR TITLE
Translate interface method modifiers

### DIFF
--- a/src/main/java/com/google/summit/translation/Translate.kt
+++ b/src/main/java/com/google/summit/translation/Translate.kt
@@ -506,19 +506,22 @@ class Translate(val file: String, private val tokens: TokenStream) : ApexParserB
   override fun visitInterfaceMethodDeclaration(
     ctx: ApexParser.InterfaceMethodDeclarationContext
   ): MethodDeclaration {
-    return MethodDeclaration(
-      id = visitId(ctx.id()),
-      returnType =
-        when {
-          ctx.VOID() != null -> TypeRef.createVoid()
-          ctx.typeRef() != null -> visitTypeRef(ctx.typeRef())
-          else -> throw TranslationException(ctx, "Method should return void or a type")
-        },
-      parameterDeclarations = visitFormalParameters(ctx.formalParameters()),
-      body = null,
-      isConstructor = false,
-      loc = toSourceLocation(ctx)
-    )
+    val decl =
+      MethodDeclaration(
+        id = visitId(ctx.id()),
+        returnType =
+          when {
+            ctx.VOID() != null -> TypeRef.createVoid()
+            ctx.typeRef() != null -> visitTypeRef(ctx.typeRef())
+            else -> throw TranslationException(ctx, "Method should return void or a type")
+          },
+        parameterDeclarations = visitFormalParameters(ctx.formalParameters()),
+        body = null,
+        isConstructor = false,
+        loc = toSourceLocation(ctx)
+      )
+    decl.modifiers = ctx.modifier().map { visitModifier(it) }
+    return decl
   }
 
   /** Translates the 'propertyDeclaration' grammar rule and returns an AST [PropertyDeclaration]. */


### PR DESCRIPTION
Interface method modifiers aren't translated.
#### Example
Input:
```apex
interface foo {
  private protected public void bar();
}
```
AST:
```json
{
  "returnType": {
    "components": [],
    "arrayNesting": 0
  },
  "parameterDeclarations": [],
  "isConstructor": false,
  "id": {
    "string": "bar"
  },
  "modifiers": []
}
```