### PR TITLE
Remove duplicate name in `ParameterDeclaration`

### DIFF
--- a/src/main/java/com/google/summit/ast/declaration/Declaration.kt
+++ b/src/main/java/com/google/summit/ast/declaration/Declaration.kt
@@ -26,7 +26,7 @@ import com.google.summit.ast.modifier.Modifier
 /**
  * A symbol declaration.
  *
- * @property id the unqualified name of the class
+ * @property id the unqualified name of the declaration
  * @param loc the location in the source file
  */
 sealed class Declaration(val id: Identifier, loc: SourceLocation) : NodeWithSourceLocation(loc) {

--- a/src/main/java/com/google/summit/ast/declaration/ParameterDeclaration.kt
+++ b/src/main/java/com/google/summit/ast/declaration/ParameterDeclaration.kt
@@ -28,8 +28,8 @@ import com.google.summit.ast.TypeRef
  * @property type the static type of the parameter
  * @param loc the location in the source file
  */
-class ParameterDeclaration(val name: Identifier, val type: TypeRef, loc: SourceLocation) :
-  Declaration(name, loc) {
+class ParameterDeclaration(id: Identifier, val type: TypeRef, loc: SourceLocation) :
+  Declaration(id, loc) {
 
-  override fun getChildren(): List<Node> = modifiers + listOf(type, name)
+  override fun getChildren(): List<Node> = modifiers + listOf(type, id)
 }

--- a/src/main/javatests/com/google/summit/testdata/mixednodes.json
+++ b/src/main/javatests/com/google/summit/testdata/mixednodes.json
@@ -167,15 +167,6 @@
         },
         "parameterDeclarations": [
           {
-            "name": {
-              "string": "a",
-              "sourceLocation": {
-                "startLine": 14,
-                "startColumn": 19,
-                "endLine": 14,
-                "endColumn": 20
-              }
-            },
             "type": {
               "components": [
                 {
@@ -211,15 +202,6 @@
             }
           },
           {
-            "name": {
-              "string": "b",
-              "sourceLocation": {
-                "startLine": 14,
-                "startColumn": 30,
-                "endLine": 14,
-                "endColumn": 31
-              }
-            },
             "type": {
               "components": [
                 {
@@ -1286,10 +1268,6 @@
           },
           "parameterDeclarations": [
             {
-              "name": {
-                "string": "value",
-                "sourceLocation": {}
-              },
               "type": {
                 "components": [
                   {

--- a/src/main/javatests/com/google/summit/translation/ClassDeclarationTest.kt
+++ b/src/main/javatests/com/google/summit/translation/ClassDeclarationTest.kt
@@ -243,7 +243,7 @@ class ClassDeclarationTest {
     assertThat(setterMethodDecl.parameterDeclarations).hasSize(1)
     val paramDecl = setterMethodDecl.parameterDeclarations.first()
     assertThat(paramDecl.type.asCodeString()).isEqualTo("String")
-    assertThat(paramDecl.name.asCodeString()).isEqualTo("value")
+    assertThat(paramDecl.id.asCodeString()).isEqualTo("value")
   }
 
   @Test

--- a/src/main/javatests/com/google/summit/translation/MethodDeclarationTest.kt
+++ b/src/main/javatests/com/google/summit/translation/MethodDeclarationTest.kt
@@ -49,7 +49,7 @@ class MethodDeclarationTest {
       .hasSize(1)
     val param = methodDecl.parameterDeclarations.first()
     assertWithMessage("Parameter should be named 'input'")
-      .that(param.name.asCodeString())
+      .that(param.id.asCodeString())
       .isEqualTo("input")
     assertWithMessage("Parameter should be a String array type")
       .that(param.type.asCodeString())


### PR DESCRIPTION
- Remove `name` property in `ParameterDeclaration`; `Declaration` already has `id`
- Fix typo in `Declaration.kt`