### PR TITLE
Create container node for comma-separated field declarations

### DIFF
--- a/src/main/java/com/google/summit/ast/declaration/ClassDeclaration.kt
+++ b/src/main/java/com/google/summit/ast/declaration/ClassDeclaration.kt
@@ -34,14 +34,14 @@ class ClassDeclaration(
   id: Identifier,
   val extendsType: TypeRef?,
   val implementsTypes: List<TypeRef>,
-  bodyDeclarations: List<Declaration>,
+  bodyDeclarations: List<Node>,
   loc: SourceLocation
 ) : TypeDeclaration(id, loc) {
 
   /** The subset of body declarations that declare an inner type (class, enum, or interface). */
   val innerTypeDeclarations = bodyDeclarations.filterIsInstance<TypeDeclaration>()
   /** The field declarations include both static and instance members. */
-  val fieldDeclarations = bodyDeclarations.filterIsInstance<FieldDeclaration>()
+  val fieldDeclarations = bodyDeclarations.filterIsInstance<FieldDeclarationGroup>()
   /** The method declarations include both static and instance methods. */
   val methodDeclarations = bodyDeclarations.filterIsInstance<MethodDeclaration>()
   /** The property declarations include both static and instance properties. */

--- a/src/main/java/com/google/summit/ast/declaration/Declaration.kt
+++ b/src/main/java/com/google/summit/ast/declaration/Declaration.kt
@@ -42,7 +42,7 @@ sealed class Declaration(val id: Identifier, loc: SourceLocation) : NodeWithSour
       }
 
   /** Returns the enclosing type declaration. */
-  fun getEnclosingType(): TypeDeclaration? = parent as? TypeDeclaration
+  open fun getEnclosingType(): TypeDeclaration? = parent as? TypeDeclaration
 }
 
 /**

--- a/src/main/java/com/google/summit/ast/declaration/Declaration.kt
+++ b/src/main/java/com/google/summit/ast/declaration/Declaration.kt
@@ -19,8 +19,7 @@ package com.google.summit.ast.declaration
 import com.google.summit.ast.Identifier
 import com.google.summit.ast.NodeWithSourceLocation
 import com.google.summit.ast.SourceLocation
-import com.google.summit.ast.modifier.AnnotationModifier
-import com.google.summit.ast.modifier.KeywordModifier
+import com.google.summit.ast.modifier.HasModifiers
 import com.google.summit.ast.modifier.Modifier
 
 /**
@@ -30,34 +29,6 @@ import com.google.summit.ast.modifier.Modifier
  * @param loc the location in the source file
  */
 sealed class Declaration(val id: Identifier, loc: SourceLocation) : NodeWithSourceLocation(loc) {
-
-  /**
-   * Constructs a declaration and sets modifiers.
-   *
-   * @param id the unqualified name of the class
-   * @param modifier the list of modifiers
-   * @param loc the location in the source file
-   */
-  constructor(id: Identifier, modifiers: List<Modifier>, loc: SourceLocation) : this(id, loc) {
-    this.modifiers = modifiers
-  }
-
-  /**
-   * The modifiers for this declaration.
-   *
-   * Because the modifiers are frequently parsed outside of the specific declaration rule in the
-   * Apex grammar, they are mutable and appended post-construction.
-   */
-  var modifiers: List<Modifier> = emptyList()
-
-  /** The subset of [modifiers] that are [annotations][AnnotationModifier]. */
-  val annotationModifiers
-    get() = modifiers.filterIsInstance<AnnotationModifier>()
-
-  /** The subset of [modifiers] that are [keywords][KeywordModifier]. */
-  val keywordModifiers
-    get() = modifiers.filterIsInstance<KeywordModifier>()
-
   /**
    * The qualified Name of the symbol includes any enclosing class(es) as prefixes, delimited by a
    * dot. For example: `OuterClass.InnerClass.innerMethod`
@@ -72,7 +43,33 @@ sealed class Declaration(val id: Identifier, loc: SourceLocation) : NodeWithSour
 
   /** Returns the enclosing type declaration. */
   fun getEnclosingType(): TypeDeclaration? = parent as? TypeDeclaration
+}
 
-  /** Returns whether this declaration has a [KeywordModifier] that matches the given [keyword]. */
-  fun hasKeyword(keyword: KeywordModifier.Keyword) = keywordModifiers.any { it.keyword == keyword }
+/**
+ * A [Declaration] that has associated [Modifier]s.
+ *
+ * @property id the unqualified name of the declaration
+ * @param loc the location in the source file
+ */
+sealed class DeclarationWithModifiers(id: Identifier, loc: SourceLocation) :
+  Declaration(id, loc), HasModifiers {
+
+  /**
+   * Constructs a declaration and sets modifiers.
+   *
+   * @param id the unqualified name of the declaration
+   * @param modifiers the list of modifiers
+   * @param loc the location in the source file
+   */
+  constructor(id: Identifier, modifiers: List<Modifier>, loc: SourceLocation) : this(id, loc) {
+    this.modifiers = modifiers
+  }
+
+  /**
+   * The modifiers for this declaration.
+   *
+   * Because the modifiers are frequently parsed outside of the specific declaration rule in the
+   * Apex grammar, they are mutable and appended post-construction.
+   */
+  final override var modifiers: List<Modifier> = emptyList()
 }

--- a/src/main/java/com/google/summit/ast/declaration/FieldDeclaration.kt
+++ b/src/main/java/com/google/summit/ast/declaration/FieldDeclaration.kt
@@ -28,14 +28,14 @@ import com.google.summit.ast.expression.Expression
  * @param id the name of the field
  * @property type a reference to the type of the field
  * @property initializer an optional initializer expression
- * @param sourceLocation the location in the source file
+ * @param loc the location in the source file
  */
 class FieldDeclaration(
   id: Identifier,
   val type: TypeRef,
   val initializer: Expression?,
   loc: SourceLocation
-) : Declaration(id, loc) {
+) : DeclarationWithModifiers(id, loc) {
 
   override fun getChildren(): List<Node> = modifiers + listOfNotNull(id, type, initializer)
 }

--- a/src/main/java/com/google/summit/ast/declaration/FieldDeclaration.kt
+++ b/src/main/java/com/google/summit/ast/declaration/FieldDeclaration.kt
@@ -63,6 +63,10 @@ class FieldDeclaration(id: Identifier, val initializer: Expression?, loc: Source
       group.modifiers = value
     }
 
+  /** The type of this field. */
+  val type: TypeRef
+    get() = group.type
+
   override fun getChildren(): List<Node> = listOfNotNull(id, initializer)
 
   override fun getEnclosingType(): TypeDeclaration? = group.parent as? TypeDeclaration

--- a/src/main/java/com/google/summit/ast/declaration/MethodDeclaration.kt
+++ b/src/main/java/com/google/summit/ast/declaration/MethodDeclaration.kt
@@ -44,7 +44,7 @@ class MethodDeclaration(
   val body: CompoundStatement?,
   val isConstructor: Boolean,
   loc: SourceLocation
-) : Declaration(id, loc) {
+) : DeclarationWithModifiers(id, loc) {
   override fun getChildren(): List<Node> =
     modifiers + listOfNotNull(id, returnType, body) + parameterDeclarations
 

--- a/src/main/java/com/google/summit/ast/declaration/ParameterDeclaration.kt
+++ b/src/main/java/com/google/summit/ast/declaration/ParameterDeclaration.kt
@@ -29,7 +29,7 @@ import com.google.summit.ast.TypeRef
  * @param loc the location in the source file
  */
 class ParameterDeclaration(id: Identifier, val type: TypeRef, loc: SourceLocation) :
-  Declaration(id, loc) {
+  DeclarationWithModifiers(id, loc) {
 
   override fun getChildren(): List<Node> = modifiers + listOf(type, id)
 }

--- a/src/main/java/com/google/summit/ast/declaration/PropertyDeclaration.kt
+++ b/src/main/java/com/google/summit/ast/declaration/PropertyDeclaration.kt
@@ -28,7 +28,7 @@ import com.google.summit.ast.TypeRef
  * @property type a reference to the type of the field
  * @property getter an optional getter method implementation
  * @property getter an optional setter method implementation
- * @param sourceLocation the location in the source file
+ * @param loc the location in the source file
  */
 class PropertyDeclaration(
   id: Identifier,
@@ -36,7 +36,7 @@ class PropertyDeclaration(
   val getter: MethodDeclaration?,
   val setter: MethodDeclaration?,
   loc: SourceLocation
-) : Declaration(id, loc) {
+) : DeclarationWithModifiers(id, loc) {
 
   override fun getChildren(): List<Node> = modifiers + listOfNotNull(id, type, getter, setter)
 }

--- a/src/main/java/com/google/summit/ast/declaration/TypeDeclaration.kt
+++ b/src/main/java/com/google/summit/ast/declaration/TypeDeclaration.kt
@@ -25,4 +25,4 @@ import com.google.summit.ast.SourceLocation
  * @param id the unqualified name of the type
  * @param loc the location in the source file
  */
-sealed class TypeDeclaration(id: Identifier, loc: SourceLocation) : Declaration(id, loc)
+sealed class TypeDeclaration(id: Identifier, loc: SourceLocation) : DeclarationWithModifiers(id, loc)

--- a/src/main/java/com/google/summit/ast/declaration/VariableDeclaration.kt
+++ b/src/main/java/com/google/summit/ast/declaration/VariableDeclaration.kt
@@ -32,7 +32,7 @@ import com.google.summit.ast.modifier.Modifier
  * @property type a reference to the type of the variable
  * @property modifiers a list of any modifiers
  * @property initializer an optional initializer expression
- * @param sourceLocation the location in the source file
+ * @param loc the location in the source file
  */
 class VariableDeclaration(
   id: Identifier,
@@ -40,7 +40,7 @@ class VariableDeclaration(
   modifiers: List<Modifier>,
   val initializer: Expression?,
   loc: SourceLocation
-) : Declaration(id, modifiers, loc) {
+) : DeclarationWithModifiers(id, modifiers, loc) {
 
   override fun getChildren(): List<Node> = modifiers + listOfNotNull(id, type, initializer)
 }

--- a/src/main/java/com/google/summit/ast/modifier/HasModifiers.kt
+++ b/src/main/java/com/google/summit/ast/modifier/HasModifiers.kt
@@ -1,0 +1,18 @@
+package com.google.summit.ast.modifier
+
+/** Indicates that a [Node][com.google.summit.ast.Node] can be modified by [Modifier]s. */
+interface HasModifiers {
+  /** The modifiers for this node. */
+  var modifiers: List<Modifier>
+
+  /** The subset of [modifiers] that are [annotations][AnnotationModifier]. */
+  val annotationModifiers
+    get() = modifiers.filterIsInstance<AnnotationModifier>()
+
+  /** The subset of [modifiers] that are [keywords][KeywordModifier]. */
+  val keywordModifiers
+    get() = modifiers.filterIsInstance<KeywordModifier>()
+
+  /** Returns whether this declaration has a [KeywordModifier] that matches the given [keyword]. */
+  fun hasKeyword(keyword: KeywordModifier.Keyword) = keywordModifiers.any { it.keyword == keyword }
+}

--- a/src/main/java/com/google/summit/translation/Translate.kt
+++ b/src/main/java/com/google/summit/translation/Translate.kt
@@ -57,6 +57,7 @@ import com.google.summit.ast.initializer.ValuesInitializer
 import com.google.summit.ast.modifier.AnnotationModifier
 import com.google.summit.ast.modifier.ElementArgument
 import com.google.summit.ast.modifier.ElementValue
+import com.google.summit.ast.modifier.HasModifiers
 import com.google.summit.ast.modifier.KeywordModifier
 import com.google.summit.ast.modifier.Modifier
 import com.google.summit.ast.statement.BreakStatement
@@ -381,7 +382,9 @@ class Translate(val file: String, private val tokens: TokenStream) : ApexParserB
     return when {
       ctx.memberDeclaration() != null -> {
         val members = visitMemberDeclaration(ctx.memberDeclaration())
-        members.forEach { member -> member.modifiers = ctx.modifier().map { visitModifier(it) } }
+        members.forEach { member ->
+          (member as HasModifiers).modifiers = ctx.modifier().map { visitModifier(it) }
+        }
         members
       }
       ctx.block() != null -> {

--- a/src/main/javatests/com/google/summit/testdata/mixednodes.json
+++ b/src/main/javatests/com/google/summit/testdata/mixednodes.json
@@ -141,16 +141,26 @@
           ],
           "arrayNesting": 0
         },
-        "modifiers": [],
-        "id": {
-          "string": "field",
-          "sourceLocation": {
-            "startLine": 6,
-            "startColumn": 10,
-            "endLine": 6,
-            "endColumn": 15
+        "declarations": [
+          {
+            "id": {
+              "string": "field",
+              "sourceLocation": {
+                "startLine": 6,
+                "startColumn": 10,
+                "endLine": 6,
+                "endColumn": 15
+              }
+            },
+            "sourceLocation": {
+              "startLine": 6,
+              "startColumn": 10,
+              "endLine": 6,
+              "endColumn": 15
+            }
           }
-        },
+        ],
+        "modifiers": [],
         "sourceLocation": {
           "startLine": 6,
           "startColumn": 2,

--- a/src/main/javatests/com/google/summit/testdata/mixednodes.json
+++ b/src/main/javatests/com/google/summit/testdata/mixednodes.json
@@ -40,6 +40,7 @@
     "innerTypeDeclarations": [
       {
         "@type": "EnumDeclaration",
+        "modifiers": [],
         "id": {
           "string": "E",
           "sourceLocation": {
@@ -49,7 +50,6 @@
             "endColumn": 8
           }
         },
-        "modifiers": [],
         "sourceLocation": {
           "startLine": 5,
           "startColumn": 2,
@@ -86,6 +86,7 @@
             },
             "parameterDeclarations": [],
             "isConstructor": false,
+            "modifiers": [],
             "id": {
               "string": "foo",
               "sourceLocation": {
@@ -95,7 +96,6 @@
                 "endColumn": 12
               }
             },
-            "modifiers": [],
             "sourceLocation": {
               "startLine": 8,
               "startColumn": 4,
@@ -104,6 +104,7 @@
             }
           }
         ],
+        "modifiers": [],
         "id": {
           "string": "I",
           "sourceLocation": {
@@ -113,7 +114,6 @@
             "endColumn": 13
           }
         },
-        "modifiers": [],
         "sourceLocation": {
           "startLine": 7,
           "startColumn": 2,
@@ -141,6 +141,7 @@
           ],
           "arrayNesting": 0
         },
+        "modifiers": [],
         "id": {
           "string": "field",
           "sourceLocation": {
@@ -150,7 +151,6 @@
             "endColumn": 15
           }
         },
-        "modifiers": [],
         "sourceLocation": {
           "startLine": 6,
           "startColumn": 2,
@@ -184,6 +184,7 @@
               ],
               "arrayNesting": 0
             },
+            "modifiers": [],
             "id": {
               "string": "a",
               "sourceLocation": {
@@ -193,7 +194,6 @@
                 "endColumn": 20
               }
             },
-            "modifiers": [],
             "sourceLocation": {
               "startLine": 14,
               "startColumn": 11,
@@ -219,6 +219,7 @@
               ],
               "arrayNesting": 0
             },
+            "modifiers": [],
             "id": {
               "string": "b",
               "sourceLocation": {
@@ -228,7 +229,6 @@
                 "endColumn": 31
               }
             },
-            "modifiers": [],
             "sourceLocation": {
               "startLine": 14,
               "startColumn": 22,
@@ -256,6 +256,7 @@
                       ],
                       "arrayNesting": 0
                     },
+                    "modifiers": [],
                     "id": {
                       "string": "e",
                       "sourceLocation": {
@@ -265,7 +266,6 @@
                         "endColumn": 24
                       }
                     },
-                    "modifiers": [],
                     "sourceLocation": {
                       "startLine": 23,
                       "startColumn": 23,
@@ -477,6 +477,7 @@
                             "endColumn": 40
                           }
                         },
+                        "modifiers": [],
                         "id": {
                           "string": "sum",
                           "sourceLocation": {
@@ -486,7 +487,6 @@
                             "endColumn": 17
                           }
                         },
-                        "modifiers": [],
                         "sourceLocation": {
                           "startLine": 17,
                           "startColumn": 6,
@@ -596,6 +596,7 @@
                             "endColumn": 70
                           }
                         },
+                        "modifiers": [],
                         "id": {
                           "string": "i",
                           "sourceLocation": {
@@ -605,7 +606,6 @@
                             "endColumn": 15
                           }
                         },
-                        "modifiers": [],
                         "sourceLocation": {
                           "startLine": 18,
                           "startColumn": 6,
@@ -813,6 +813,7 @@
                             "endColumn": 99
                           }
                         },
+                        "modifiers": [],
                         "id": {
                           "string": "MyStrings",
                           "sourceLocation": {
@@ -822,7 +823,6 @@
                             "endColumn": 35
                           }
                         },
-                        "modifiers": [],
                         "sourceLocation": {
                           "startLine": 19,
                           "startColumn": 6,
@@ -1149,6 +1149,7 @@
           }
         },
         "isConstructor": false,
+        "modifiers": [],
         "id": {
           "string": "foo",
           "sourceLocation": {
@@ -1158,7 +1159,6 @@
             "endColumn": 10
           }
         },
-        "modifiers": [],
         "sourceLocation": {
           "startLine": 14,
           "startColumn": 2,
@@ -1244,6 +1244,7 @@
             }
           },
           "isConstructor": false,
+          "modifiers": [],
           "id": {
             "string": "get",
             "sourceLocation": {
@@ -1253,7 +1254,6 @@
               "endColumn": 7
             }
           },
-          "modifiers": [],
           "sourceLocation": {
             "startLine": 11,
             "startColumn": 4,
@@ -1285,11 +1285,11 @@
                 ],
                 "arrayNesting": 0
               },
+              "modifiers": [],
               "id": {
                 "string": "value",
                 "sourceLocation": {}
               },
-              "modifiers": [],
               "sourceLocation": {}
             }
           ],
@@ -1359,6 +1359,7 @@
             }
           },
           "isConstructor": false,
+          "modifiers": [],
           "id": {
             "string": "set",
             "sourceLocation": {
@@ -1368,7 +1369,6 @@
               "endColumn": 7
             }
           },
-          "modifiers": [],
           "sourceLocation": {
             "startLine": 12,
             "startColumn": 4,
@@ -1376,6 +1376,7 @@
             "endColumn": 29
           }
         },
+        "modifiers": [],
         "id": {
           "string": "property",
           "sourceLocation": {
@@ -1385,7 +1386,6 @@
             "endColumn": 17
           }
         },
-        "modifiers": [],
         "sourceLocation": {
           "startLine": 10,
           "startColumn": 2,
@@ -1394,15 +1394,6 @@
         }
       }
     ],
-    "id": {
-      "string": "Main",
-      "sourceLocation": {
-        "startLine": 4,
-        "startColumn": 13,
-        "endLine": 4,
-        "endColumn": 17
-      }
-    },
     "modifiers": [
       {
         "@type": "AnnotationModifier",
@@ -1584,6 +1575,15 @@
         }
       }
     ],
+    "id": {
+      "string": "Main",
+      "sourceLocation": {
+        "startLine": 4,
+        "startColumn": 13,
+        "endLine": 4,
+        "endColumn": 17
+      }
+    },
     "sourceLocation": {
       "startLine": 4,
       "startColumn": 7,

--- a/src/main/javatests/com/google/summit/testdata/vardecl.json
+++ b/src/main/javatests/com/google/summit/testdata/vardecl.json
@@ -189,6 +189,7 @@
           "endColumn": 99
         }
       },
+      "modifiers": [],
       "id": {
         "string": "MyStrings",
         "sourceLocation": {
@@ -198,7 +199,6 @@
           "endColumn": 35
         }
       },
-      "modifiers": [],
       "sourceLocation": {
         "startLine": 19,
         "startColumn": 6,

--- a/src/main/javatests/com/google/summit/translation/ClassDeclarationTest.kt
+++ b/src/main/javatests/com/google/summit/translation/ClassDeclarationTest.kt
@@ -107,6 +107,7 @@ class ClassDeclarationTest {
     assertThat(fieldDecl.modifiers).hasSize(1)
     assertThat(fieldDecl.hasKeyword(KeywordModifier.Keyword.PUBLIC)).isTrue()
     assertThat(fieldDecl.initializer).isNotNull()
+    assertThat(fieldDecl.type.asCodeString()).isEqualTo("String")
   }
 
   @Test


### PR DESCRIPTION
#### Context
The current representation of field declarations is too abstract. Comma-separated fields are translated as if they were separate declarations.

This has an effect on PMD rules like [OneDeclarationPerLine](https://github.com/pmd/pmd/blob/master/pmd-apex/src/main/resources/category/apex/codestyle.xml#L272), which would not have sufficient information about fields to detect multiple declarations in one line.

#### Changes
- Move modifier logic from `Declaration` to new `Modifiable` interface. Not all declarations have modifiers, and some nodes that aren't declarations have modifiers.
- Create `FieldDeclarationGroup` container node for comma-separated field declarations.

See individual commit messages for more details