### PR TITLE
Fix `visitWhenLiteral`

### DIFF
--- a/src/main/java/com/google/summit/translation/Translate.kt
+++ b/src/main/java/com/google/summit/translation/Translate.kt
@@ -882,7 +882,8 @@ class Translate(val file: String, private val tokens: TokenStream) : ApexParserB
         }
         ctx.LongLiteral() != null ->
           LiteralExpression.LongVal(text.replace("[lL]$".toRegex(), "").toLong(), loc)
-        ctx.StringLiteral() != null -> LiteralExpression.StringVal(text, loc)
+        ctx.StringLiteral() != null ->
+          LiteralExpression.StringVal(text.removeSurrounding("'", "'"), loc)
         ctx.NULL() != null -> LiteralExpression.NullVal(loc)
         // An identifier is an enum value
         ctx.id() != null -> VariableExpression(visitId(ctx.id()), loc)

--- a/src/main/java/com/google/summit/translation/Translate.kt
+++ b/src/main/java/com/google/summit/translation/Translate.kt
@@ -870,13 +870,15 @@ class Translate(val file: String, private val tokens: TokenStream) : ApexParserB
     return try {
       when {
         ctx.IntegerLiteral() != null -> {
-          val signMultiplier =
-            if (ctx.SUB() != null) {
-              -1
-            } else {
-              1
-            }
-          LiteralExpression.IntegerVal(text.toInt() * signMultiplier, loc)
+          val absoluteValue = ctx.IntegerLiteral().text.toInt() // value without sign
+          val integerVal =
+            LiteralExpression.IntegerVal(absoluteValue, toSourceLocation(ctx.IntegerLiteral()))
+
+          if (ctx.SUB() != null) {
+            UnaryExpression(value = integerVal, op = UnaryExpression.Operator.NEGATION, loc)
+          } else {
+            integerVal
+          }
         }
         ctx.LongLiteral() != null ->
           LiteralExpression.LongVal(text.replace("[lL]$".toRegex(), "").toLong(), loc)


### PR DESCRIPTION
`visitWhenLiteral` does not translate integer & string literals correctly.

#### Example input
```apex
switch on (x) {
  when 'a' {}
  when 1, - 1 {}
}
```

#### Current AST output
```jsonc
{
  "@type": "SwitchStatement",
  "condition": { /* ... */ },
  "whenClauses": [
    {
      "@type": "WhenValue",
      "values": [
        {
          "@type": "StringVal",
          "value": "'a'" // single quotes included
        }
      ],
      "statement": { /* ... */ }
    },
    {
      "@type": "WhenValue",
      "values": [
        {
          "@type": "IntegerVal",
          "value": 1
        },
        {
          "@type": "IntegerVal",
          "value": 1 // not negative
        }
      ],
      "statement": { /* ... */ }
    }
  ]
}
```

#### Adjusted AST output
```jsonc
{
  "@type": "SwitchStatement",
  "condition": { /* ... */ },
  "whenClauses": [
    {
      "@type": "WhenValue",
      "values": [
        {
          "@type": "StringVal",
          "value": "a" // correct value
        }
      ],
      "statement": { /* ... */ }
    },
    {
      "@type": "WhenValue",
      "values": [
        {
          "@type": "IntegerVal",
          "value": 1
        },
        {
          "@type": "UnaryExpression", // negative number represented by NEGATION operator to match normal expression structure
          "value": {
            "@type": "IntegerVal",
            "value": 1
          },
          "op": "NEGATION"
        }
      ],
      "statement": { /* ... */ }
    }
  ]
}
```