### PR TITLE
Implement `spanOf` method to compute the`SourceLocation` that encloses one or more others.

### DIFF
--- a/src/main/java/com/google/summit/ast/SourceLocation.kt
+++ b/src/main/java/com/google/summit/ast/SourceLocation.kt
@@ -93,8 +93,12 @@ private fun maxEnd(x: SourceLocation, y: SourceLocation) =
     else -> y
   }
 
-/** Unions one or more [SourceLocation] ranges to the containing range. */
-fun unionOf(vararg locs: SourceLocation): SourceLocation {
+/**
+  * Span of one or more [SourceLocation] ranges.
+  *
+  * The result is the minimal range that encloses them all.
+  */
+fun spanOf(vararg locs: SourceLocation): SourceLocation {
   val start = locs.reduce { x, y -> minStart(x, y) }
   val end = locs.reduce { x, y -> maxEnd(x, y) }
   return SourceLocation(

--- a/src/main/java/com/google/summit/ast/SourceLocation.kt
+++ b/src/main/java/com/google/summit/ast/SourceLocation.kt
@@ -66,3 +66,38 @@ data class SourceLocation(
     val UNKNOWN = SourceLocation(null, null, null, null)
   }
 }
+
+/** Returns the [SourceLocation] with the minimum start position. */
+private fun minStart(x: SourceLocation, y: SourceLocation) =
+  when {
+    x.startLine == null -> y
+    y.startLine == null -> x
+    x.startLine < y.startLine -> x
+    y.startLine < x.startLine -> y
+    x.startColumn == null -> y
+    y.startColumn == null -> x
+    x.startColumn < y.startColumn -> x
+    else -> y
+  }
+
+/** Returns the [SourceLocation] with the maximum end position. */
+private fun maxEnd(x: SourceLocation, y: SourceLocation) =
+  when {
+    x.endLine == null -> y
+    y.endLine == null -> x
+    x.endLine > y.endLine -> x
+    y.endLine > x.endLine -> y
+    x.endColumn == null -> y
+    y.endColumn == null -> x
+    x.endColumn > y.endColumn -> x
+    else -> y
+  }
+
+/** Unions one or more [SourceLocation] ranges to the containing range. */
+fun unionOf(vararg locs: SourceLocation): SourceLocation {
+  val start = locs.reduce { x, y -> minStart(x, y) }
+  val end = locs.reduce { x, y -> maxEnd(x, y) }
+  return SourceLocation(
+    start.startLine, start.startColumn, end.endLine, end.endColumn
+  )
+}

--- a/src/main/javatests/com/google/summit/ast/SourceLocationTest.kt
+++ b/src/main/javatests/com/google/summit/ast/SourceLocationTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.summit.ast
+
+import com.google.common.truth.Truth.assertThat
+import com.google.summit.ast.Node
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(JUnit4::class)
+class SourceLocationTest {
+
+  @Test
+  fun unionOf_chooses_nonNullValues() {
+    val unknown = SourceLocation.UNKNOWN
+    val withLinesOnly = SourceLocation(1, null, 3, null)
+    val withLinesAndColumns = SourceLocation(withLinesOnly.startLine, 10, withLinesOnly.endLine, 10)
+
+    assertThat(unionOf(unknown, unknown)).isEqualTo(unknown)
+    assertThat(unionOf(withLinesOnly, unknown)).isEqualTo(withLinesOnly)
+    assertThat(unionOf(unknown, withLinesOnly)).isEqualTo(withLinesOnly)
+    assertThat(unionOf(withLinesOnly, withLinesAndColumns)).isEqualTo(withLinesAndColumns)
+    assertThat(unionOf(withLinesAndColumns, withLinesOnly)).isEqualTo(withLinesAndColumns)
+  }
+
+  @Test
+  fun unionOf_returns_newRange() {
+    val lower = SourceLocation(1, 1, 2, 2)
+    val upper = SourceLocation(2, 2, 3, 3)
+
+    val expected = SourceLocation(lower.startLine, lower.startColumn,
+                                  upper.endLine, upper.endColumn)
+    assertThat(unionOf(lower, upper)).isEqualTo(expected)
+    assertThat(unionOf(upper, lower)).isEqualTo(expected)
+  }
+
+  @Test
+  fun unionOf_is_idempotent() {
+    val loc = SourceLocation(1, 3, 4, 2)
+
+    assertThat(unionOf(loc)).isEqualTo(loc)
+    assertThat(unionOf(loc, loc, loc)).isEqualTo(loc)
+    assertThat(unionOf(loc, unionOf(loc, loc))).isEqualTo(loc)
+  }
+
+  @Test
+  fun unionOf_ranks_lineOverColumn() {
+    val widerLines = SourceLocation(1, 6, 10, 5)
+    val widerColumns = SourceLocation(5, 1, 6, 10)
+
+    assertThat(unionOf(widerLines, widerColumns)).isEqualTo(widerLines)
+    assertThat(unionOf(widerColumns, widerLines)).isEqualTo(widerLines)
+  }
+}

--- a/src/main/javatests/com/google/summit/ast/SourceLocationTest.kt
+++ b/src/main/javatests/com/google/summit/ast/SourceLocationTest.kt
@@ -26,44 +26,44 @@ import org.junit.runners.JUnit4
 class SourceLocationTest {
 
   @Test
-  fun unionOf_chooses_nonNullValues() {
+  fun spanOf_chooses_nonNullValues() {
     val unknown = SourceLocation.UNKNOWN
     val withLinesOnly = SourceLocation(1, null, 3, null)
     val withLinesAndColumns = SourceLocation(withLinesOnly.startLine, 10, withLinesOnly.endLine, 10)
 
-    assertThat(unionOf(unknown, unknown)).isEqualTo(unknown)
-    assertThat(unionOf(withLinesOnly, unknown)).isEqualTo(withLinesOnly)
-    assertThat(unionOf(unknown, withLinesOnly)).isEqualTo(withLinesOnly)
-    assertThat(unionOf(withLinesOnly, withLinesAndColumns)).isEqualTo(withLinesAndColumns)
-    assertThat(unionOf(withLinesAndColumns, withLinesOnly)).isEqualTo(withLinesAndColumns)
+    assertThat(spanOf(unknown, unknown)).isEqualTo(unknown)
+    assertThat(spanOf(withLinesOnly, unknown)).isEqualTo(withLinesOnly)
+    assertThat(spanOf(unknown, withLinesOnly)).isEqualTo(withLinesOnly)
+    assertThat(spanOf(withLinesOnly, withLinesAndColumns)).isEqualTo(withLinesAndColumns)
+    assertThat(spanOf(withLinesAndColumns, withLinesOnly)).isEqualTo(withLinesAndColumns)
   }
 
   @Test
-  fun unionOf_returns_newRange() {
+  fun spanOf_returns_newRange() {
     val lower = SourceLocation(1, 1, 2, 2)
     val upper = SourceLocation(2, 2, 3, 3)
 
     val expected = SourceLocation(lower.startLine, lower.startColumn,
                                   upper.endLine, upper.endColumn)
-    assertThat(unionOf(lower, upper)).isEqualTo(expected)
-    assertThat(unionOf(upper, lower)).isEqualTo(expected)
+    assertThat(spanOf(lower, upper)).isEqualTo(expected)
+    assertThat(spanOf(upper, lower)).isEqualTo(expected)
   }
 
   @Test
-  fun unionOf_is_idempotent() {
+  fun spanOf_is_idempotent() {
     val loc = SourceLocation(1, 3, 4, 2)
 
-    assertThat(unionOf(loc)).isEqualTo(loc)
-    assertThat(unionOf(loc, loc, loc)).isEqualTo(loc)
-    assertThat(unionOf(loc, unionOf(loc, loc))).isEqualTo(loc)
+    assertThat(spanOf(loc)).isEqualTo(loc)
+    assertThat(spanOf(loc, loc, loc)).isEqualTo(loc)
+    assertThat(spanOf(loc, spanOf(loc, loc))).isEqualTo(loc)
   }
 
   @Test
-  fun unionOf_ranks_lineOverColumn() {
+  fun spanOf_ranks_lineOverColumn() {
     val widerLines = SourceLocation(1, 6, 10, 5)
     val widerColumns = SourceLocation(5, 1, 6, 10)
 
-    assertThat(unionOf(widerLines, widerColumns)).isEqualTo(widerLines)
-    assertThat(unionOf(widerColumns, widerLines)).isEqualTo(widerLines)
+    assertThat(spanOf(widerLines, widerColumns)).isEqualTo(widerLines)
+    assertThat(spanOf(widerColumns, widerLines)).isEqualTo(widerLines)
   }
 }


### PR DESCRIPTION
Implement `unionOf` method to compute the containing range of one or more `SourceLocation` values

Add unit tests of several cases: null, reflexivity, idempotency, others.

This enhancement is to support PMD nodes that map to multiple Summit nodes: their source intervals will be the union of the Summit nodes.