### PR TITLE
Drop square brackets around SoqlExpression query string

### DIFF
--- a/src/main/java/com/google/summit/translation/Translate.kt
+++ b/src/main/java/com/google/summit/translation/Translate.kt
@@ -1331,7 +1331,7 @@ class Translate(val file: String, private val tokens: TokenStream) : ApexParserB
 
   /** Translates the 'soqlLiteral' grammar rule and returns an AST [SoqlExpression]. */
   override fun visitSoqlLiteral(ctx: ApexParser.SoqlLiteralContext) =
-    SoqlExpression(toSourceString(ctx),
+    SoqlExpression(toSourceString(ctx.query()),
                    visitQuery(ctx.query()).bindings,
                    toSourceLocation(ctx))
 
@@ -1341,9 +1341,11 @@ class Translate(val file: String, private val tokens: TokenStream) : ApexParserB
       *visitSoslClauses(ctx.soslClauses()).bindings.toTypedArray(),
       ctx.boundExpression()?.let { visitBoundExpression(it) },
     ).filterNotNull()
-    return SoslExpression(toSourceString(ctx),
-                          bindings,
-                          toSourceLocation(ctx))
+    return SoslExpression(
+        toSourceString(ctx).trim().removeSurrounding("[","]"),
+        bindings,
+        toSourceLocation(ctx)
+    )
   }
 
   /** Translates the 'boundExpression' grammar rule and returns a [SoqlOrSoslBinding]. */

--- a/src/main/javatests/com/google/summit/testdata/mixednodes.json
+++ b/src/main/javatests/com/google/summit/testdata/mixednodes.json
@@ -601,7 +601,7 @@
                             },
                             "thenValue": {
                               "@type": "SoqlExpression",
-                              "query": "[SELECT COUNT() FROM Account]",
+                              "query": "SELECT COUNT() FROM Account",
                               "bindings": [],
                               "sourceLocation": {
                                 "startLine": 18,

--- a/src/main/javatests/com/google/summit/translation/SoqlAndSoslTest.kt
+++ b/src/main/javatests/com/google/summit/translation/SoqlAndSoslTest.kt
@@ -66,7 +66,7 @@ class SoqlAndSoslTest {
 
     val node = TranslateHelpers.findFirstNodeOfType<SoqlExpression>(root)
     assertThat(node).isNotNull()
-    assertThat(node!!.query).isEqualTo("[$query]")
+    assertThat(node!!.query).isEqualTo(query)
     assertThat(node.bindings).isEmpty()
   }
 
@@ -78,7 +78,7 @@ class SoqlAndSoslTest {
 
     val node = TranslateHelpers.findFirstNodeOfType<SoslExpression>(root)
     assertThat(node).isNotNull()
-    assertThat(node!!.query).isEqualTo("[$query]")
+    assertThat(node!!.query).isEqualTo(query)
     assertThat(node.bindings).hasSize(1)
   }
 }


### PR DESCRIPTION
Reason: these are part of the Apex syntax and not the SOQL.

Motivation: to match the expected PMD query string.

Update unit tests.