### PR TITLE
Add TypeRef.getTypeErasedString

### DIFF
--- a/src/main/java/com/google/summit/ast/TypeRef.kt
+++ b/src/main/java/com/google/summit/ast/TypeRef.kt
@@ -69,6 +69,18 @@ class TypeRef(val components: List<Component>, val arrayNesting: Int) :
       components.joinToString(".") { it.asCodeString() } + "[]".repeat(arrayNesting)
     }
 
+  /**
+   * Returns the type reference as a type-erased string.
+   *
+   * This is the same as [asCodeString] but without any type arguments.
+   */
+  fun asTypeErasedString(): String =
+    if (isVoid()) {
+      "void"
+    } else {
+      components.joinToString(".") { it.id.asCodeString() } + "[]".repeat(arrayNesting)
+    }
+
   /** Returns an unknown location, but the constituent identifiers have locations. */
   override fun getSourceLocation(): SourceLocation = SourceLocation.UNKNOWN
 

--- a/src/main/javatests/com/google/summit/translation/TypeRefTest.kt
+++ b/src/main/javatests/com/google/summit/translation/TypeRefTest.kt
@@ -48,6 +48,7 @@ class TypeRefTest {
     assertThat(outerTypeRefNode.components[1].args).hasSize(2) // C, D.E<F>
     assertThat(outerTypeRefNode.components[1].args[1].components).hasSize(2) // D, E
     assertThat(outerTypeRefNode.components[1].args[1].components[1].args).hasSize(1) // F
+    assertThat(outerTypeRefNode.asTypeErasedString()).isEqualTo("A.B");
   }
 
   @Test
@@ -58,6 +59,8 @@ class TypeRefTest {
 
     assertNotNull(typeRefNode)
     assertThat(typeRefNode.arrayNesting).isEqualTo(2)
+    assertThat(typeRefNode.asCodeString()).isEqualTo("A[][]")
+    assertThat(typeRefNode.asTypeErasedString()).isEqualTo("A[][]")
   }
 
   @Test
@@ -69,5 +72,6 @@ class TypeRefTest {
 
     assertNotNull(typeRefNode)
     assertThat(typeRefNode.asCodeString()).isEqualTo("Map<String>")
+    assertThat(typeRefNode.asTypeErasedString()).isEqualTo("Map")
   }
 }


### PR DESCRIPTION
This returns type names without (compile-time-only) type arguments.

Add unit tests.