### PR TITLE
Reorder class body declarations (with properties before methods).

### DIFF
--- a/src/main/java/com/google/summit/ast/Node.kt
+++ b/src/main/java/com/google/summit/ast/Node.kt
@@ -62,6 +62,9 @@ abstract class Node {
    * should only be the child of exactly one parent, and there must be no cycles in the
    * relationship.
    *
+   * The order of the children is stable but may differ from their positional order in the
+   * input source.
+   *
    * The bottom-up tree creation implies that the children already exist when the parent node is
    * constructed, and so the list of children should be fixed from initialization onward.
    */

--- a/src/main/java/com/google/summit/ast/declaration/ClassDeclaration.kt
+++ b/src/main/java/com/google/summit/ast/declaration/ClassDeclaration.kt
@@ -42,10 +42,10 @@ class ClassDeclaration(
   val innerTypeDeclarations = bodyDeclarations.filterIsInstance<TypeDeclaration>()
   /** The field declarations include both static and instance members. */
   val fieldDeclarations = bodyDeclarations.filterIsInstance<FieldDeclarationGroup>()
-  /** The method declarations include both static and instance methods. */
-  val methodDeclarations = bodyDeclarations.filterIsInstance<MethodDeclaration>()
   /** The property declarations include both static and instance properties. */
   val propertyDeclarations = bodyDeclarations.filterIsInstance<PropertyDeclaration>()
+  /** The method declarations include both static and instance methods. */
+  val methodDeclarations = bodyDeclarations.filterIsInstance<MethodDeclaration>()
 
   override fun getChildren(): List<Node> =
     modifiers +
@@ -53,6 +53,6 @@ class ClassDeclaration(
       implementsTypes +
       innerTypeDeclarations +
       fieldDeclarations +
-      methodDeclarations +
-      propertyDeclarations
+      propertyDeclarations +
+      methodDeclarations
 }

--- a/src/main/javatests/com/google/summit/testdata/mixednodes.json
+++ b/src/main/javatests/com/google/summit/testdata/mixednodes.json
@@ -204,6 +204,233 @@
         }
       }
     ],
+    "propertyDeclarations": [
+      {
+        "type": {
+          "components": [
+            {
+              "id": {
+                "string": "String",
+                "sourceLocation": {
+                  "startLine": 10,
+                  "startColumn": 2,
+                  "endLine": 10,
+                  "endColumn": 8
+                }
+              },
+              "args": []
+            }
+          ],
+          "arrayNesting": 0
+        },
+        "getter": {
+          "returnType": {
+            "components": [
+              {
+                "id": {
+                  "string": "String",
+                  "sourceLocation": {
+                    "startLine": 10,
+                    "startColumn": 2,
+                    "endLine": 10,
+                    "endColumn": 8
+                  }
+                },
+                "args": []
+              }
+            ],
+            "arrayNesting": 0
+          },
+          "parameterDeclarations": [],
+          "body": {
+            "statements": [
+              {
+                "@type": "ReturnStatement",
+                "value": {
+                  "@type": "VariableExpression",
+                  "id": {
+                    "string": "property",
+                    "sourceLocation": {
+                      "startLine": 11,
+                      "startColumn": 17,
+                      "endLine": 11,
+                      "endColumn": 25
+                    }
+                  },
+                  "sourceLocation": {
+                    "startLine": 11,
+                    "startColumn": 17,
+                    "endLine": 11,
+                    "endColumn": 25
+                  }
+                },
+                "sourceLocation": {
+                  "startLine": 11,
+                  "startColumn": 10,
+                  "endLine": 11,
+                  "endColumn": 26
+                }
+              }
+            ],
+            "scoping": "SCOPE_BOUNDARY",
+            "sourceLocation": {
+              "startLine": 11,
+              "startColumn": 8,
+              "endLine": 11,
+              "endColumn": 28
+            }
+          },
+          "isConstructor": false,
+          "modifiers": [],
+          "id": {
+            "string": "get",
+            "sourceLocation": {
+              "startLine": 11,
+              "startColumn": 4,
+              "endLine": 11,
+              "endColumn": 7
+            }
+          },
+          "sourceLocation": {
+            "startLine": 11,
+            "startColumn": 4,
+            "endLine": 11,
+            "endColumn": 28
+          }
+        },
+        "setter": {
+          "returnType": {
+            "components": [],
+            "arrayNesting": 0
+          },
+          "parameterDeclarations": [
+            {
+              "type": {
+                "components": [
+                  {
+                    "id": {
+                      "string": "String",
+                      "sourceLocation": {
+                        "startLine": 10,
+                        "startColumn": 2,
+                        "endLine": 10,
+                        "endColumn": 8
+                      }
+                    },
+                    "args": []
+                  }
+                ],
+                "arrayNesting": 0
+              },
+              "modifiers": [],
+              "id": {
+                "string": "value",
+                "sourceLocation": {}
+              },
+              "sourceLocation": {}
+            }
+          ],
+          "body": {
+            "statements": [
+              {
+                "@type": "ExpressionStatement",
+                "expression": {
+                  "@type": "AssignExpression",
+                  "target": {
+                    "@type": "VariableExpression",
+                    "id": {
+                      "string": "property",
+                      "sourceLocation": {
+                        "startLine": 12,
+                        "startColumn": 10,
+                        "endLine": 12,
+                        "endColumn": 18
+                      }
+                    },
+                    "sourceLocation": {
+                      "startLine": 12,
+                      "startColumn": 10,
+                      "endLine": 12,
+                      "endColumn": 18
+                    }
+                  },
+                  "source": {
+                    "@type": "VariableExpression",
+                    "id": {
+                      "string": "value",
+                      "sourceLocation": {
+                        "startLine": 12,
+                        "startColumn": 21,
+                        "endLine": 12,
+                        "endColumn": 26
+                      }
+                    },
+                    "sourceLocation": {
+                      "startLine": 12,
+                      "startColumn": 21,
+                      "endLine": 12,
+                      "endColumn": 26
+                    }
+                  },
+                  "sourceLocation": {
+                    "startLine": 12,
+                    "startColumn": 10,
+                    "endLine": 12,
+                    "endColumn": 26
+                  }
+                },
+                "sourceLocation": {
+                  "startLine": 12,
+                  "startColumn": 10,
+                  "endLine": 12,
+                  "endColumn": 27
+                }
+              }
+            ],
+            "scoping": "SCOPE_BOUNDARY",
+            "sourceLocation": {
+              "startLine": 12,
+              "startColumn": 8,
+              "endLine": 12,
+              "endColumn": 29
+            }
+          },
+          "isConstructor": false,
+          "modifiers": [],
+          "id": {
+            "string": "set",
+            "sourceLocation": {
+              "startLine": 12,
+              "startColumn": 4,
+              "endLine": 12,
+              "endColumn": 7
+            }
+          },
+          "sourceLocation": {
+            "startLine": 12,
+            "startColumn": 4,
+            "endLine": 12,
+            "endColumn": 29
+          }
+        },
+        "modifiers": [],
+        "id": {
+          "string": "property",
+          "sourceLocation": {
+            "startLine": 10,
+            "startColumn": 9,
+            "endLine": 10,
+            "endColumn": 17
+          }
+        },
+        "sourceLocation": {
+          "startLine": 10,
+          "startColumn": 2,
+          "endLine": 13,
+          "endColumn": 3
+        }
+      }
+    ],
     "methodDeclarations": [
       {
         "returnType": {
@@ -1244,233 +1471,6 @@
           "startLine": 14,
           "startColumn": 2,
           "endLine": 24,
-          "endColumn": 3
-        }
-      }
-    ],
-    "propertyDeclarations": [
-      {
-        "type": {
-          "components": [
-            {
-              "id": {
-                "string": "String",
-                "sourceLocation": {
-                  "startLine": 10,
-                  "startColumn": 2,
-                  "endLine": 10,
-                  "endColumn": 8
-                }
-              },
-              "args": []
-            }
-          ],
-          "arrayNesting": 0
-        },
-        "getter": {
-          "returnType": {
-            "components": [
-              {
-                "id": {
-                  "string": "String",
-                  "sourceLocation": {
-                    "startLine": 10,
-                    "startColumn": 2,
-                    "endLine": 10,
-                    "endColumn": 8
-                  }
-                },
-                "args": []
-              }
-            ],
-            "arrayNesting": 0
-          },
-          "parameterDeclarations": [],
-          "body": {
-            "statements": [
-              {
-                "@type": "ReturnStatement",
-                "value": {
-                  "@type": "VariableExpression",
-                  "id": {
-                    "string": "property",
-                    "sourceLocation": {
-                      "startLine": 11,
-                      "startColumn": 17,
-                      "endLine": 11,
-                      "endColumn": 25
-                    }
-                  },
-                  "sourceLocation": {
-                    "startLine": 11,
-                    "startColumn": 17,
-                    "endLine": 11,
-                    "endColumn": 25
-                  }
-                },
-                "sourceLocation": {
-                  "startLine": 11,
-                  "startColumn": 10,
-                  "endLine": 11,
-                  "endColumn": 26
-                }
-              }
-            ],
-            "scoping": "SCOPE_BOUNDARY",
-            "sourceLocation": {
-              "startLine": 11,
-              "startColumn": 8,
-              "endLine": 11,
-              "endColumn": 28
-            }
-          },
-          "isConstructor": false,
-          "modifiers": [],
-          "id": {
-            "string": "get",
-            "sourceLocation": {
-              "startLine": 11,
-              "startColumn": 4,
-              "endLine": 11,
-              "endColumn": 7
-            }
-          },
-          "sourceLocation": {
-            "startLine": 11,
-            "startColumn": 4,
-            "endLine": 11,
-            "endColumn": 28
-          }
-        },
-        "setter": {
-          "returnType": {
-            "components": [],
-            "arrayNesting": 0
-          },
-          "parameterDeclarations": [
-            {
-              "type": {
-                "components": [
-                  {
-                    "id": {
-                      "string": "String",
-                      "sourceLocation": {
-                        "startLine": 10,
-                        "startColumn": 2,
-                        "endLine": 10,
-                        "endColumn": 8
-                      }
-                    },
-                    "args": []
-                  }
-                ],
-                "arrayNesting": 0
-              },
-              "modifiers": [],
-              "id": {
-                "string": "value",
-                "sourceLocation": {}
-              },
-              "sourceLocation": {}
-            }
-          ],
-          "body": {
-            "statements": [
-              {
-                "@type": "ExpressionStatement",
-                "expression": {
-                  "@type": "AssignExpression",
-                  "target": {
-                    "@type": "VariableExpression",
-                    "id": {
-                      "string": "property",
-                      "sourceLocation": {
-                        "startLine": 12,
-                        "startColumn": 10,
-                        "endLine": 12,
-                        "endColumn": 18
-                      }
-                    },
-                    "sourceLocation": {
-                      "startLine": 12,
-                      "startColumn": 10,
-                      "endLine": 12,
-                      "endColumn": 18
-                    }
-                  },
-                  "source": {
-                    "@type": "VariableExpression",
-                    "id": {
-                      "string": "value",
-                      "sourceLocation": {
-                        "startLine": 12,
-                        "startColumn": 21,
-                        "endLine": 12,
-                        "endColumn": 26
-                      }
-                    },
-                    "sourceLocation": {
-                      "startLine": 12,
-                      "startColumn": 21,
-                      "endLine": 12,
-                      "endColumn": 26
-                    }
-                  },
-                  "sourceLocation": {
-                    "startLine": 12,
-                    "startColumn": 10,
-                    "endLine": 12,
-                    "endColumn": 26
-                  }
-                },
-                "sourceLocation": {
-                  "startLine": 12,
-                  "startColumn": 10,
-                  "endLine": 12,
-                  "endColumn": 27
-                }
-              }
-            ],
-            "scoping": "SCOPE_BOUNDARY",
-            "sourceLocation": {
-              "startLine": 12,
-              "startColumn": 8,
-              "endLine": 12,
-              "endColumn": 29
-            }
-          },
-          "isConstructor": false,
-          "modifiers": [],
-          "id": {
-            "string": "set",
-            "sourceLocation": {
-              "startLine": 12,
-              "startColumn": 4,
-              "endLine": 12,
-              "endColumn": 7
-            }
-          },
-          "sourceLocation": {
-            "startLine": 12,
-            "startColumn": 4,
-            "endLine": 12,
-            "endColumn": 29
-          }
-        },
-        "modifiers": [],
-        "id": {
-          "string": "property",
-          "sourceLocation": {
-            "startLine": 10,
-            "startColumn": 9,
-            "endLine": 10,
-            "endColumn": 17
-          }
-        },
-        "sourceLocation": {
-          "startLine": 10,
-          "startColumn": 2,
-          "endLine": 13,
           "endColumn": 3
         }
       }


### PR DESCRIPTION
This is a semi-unprincipled change that is sufficient to fix PMD tests.

We may want to revisit later whether class body declarations -- or even all children in general --  should be traversed in the same order as they appear in the source code. (This is not straightforward to do for class body declarations because of the constraints imposed by the serialization approach.)

Add unit test.
