### PR TITLE
Reorder MethodDeclaration.getChildren() with parameters before body

### DIFF
--- a/src/main/java/com/google/summit/ast/declaration/MethodDeclaration.kt
+++ b/src/main/java/com/google/summit/ast/declaration/MethodDeclaration.kt
@@ -46,7 +46,7 @@ class MethodDeclaration(
   loc: SourceLocation
 ) : DeclarationWithModifiers(id, loc) {
   override fun getChildren(): List<Node> =
-    modifiers + listOfNotNull(id, returnType, body) + parameterDeclarations
+    modifiers + listOf(id, returnType) + parameterDeclarations + listOfNotNull(body)
 
   /**
    * Returns whether this method is an anonymous initialization block.

--- a/src/main/javatests/com/google/summit/translation/MethodDeclarationTest.kt
+++ b/src/main/javatests/com/google/summit/translation/MethodDeclarationTest.kt
@@ -21,6 +21,7 @@ import com.google.common.truth.Truth.assertWithMessage
 import com.google.summit.ast.declaration.ClassDeclaration
 import com.google.summit.ast.declaration.MethodDeclaration
 import com.google.summit.ast.modifier.KeywordModifier
+import com.google.summit.ast.statement.CompoundStatement
 import com.google.summit.testing.TranslateHelpers
 import kotlin.test.assertNotNull
 import org.junit.Test
@@ -111,5 +112,25 @@ class MethodDeclarationTest {
 
     val constructorDecl = classDecl.methodDeclarations.last()
     assertThat(constructorDecl.isConstructor).isTrue()
+  }
+
+  @Test
+  fun method_getChildren_ordering() {
+    val input =
+      """
+        class Test {
+          public String f(Integer i) { }
+        }
+        """
+
+    val methodDecl = TranslateHelpers.parseAndFindFirstNodeOfType<MethodDeclaration>(input)
+
+    assertNotNull(methodDecl)
+    assertWithMessage("MethodDeclaration.getChildren() should list the body last")
+      .that(
+        methodDecl
+          .getChildren()
+          .last()
+      ).isInstanceOf(CompoundStatement::class.java)
   }
 }


### PR DESCRIPTION
Traverse a method's parameters before its body, such that the parameters are declared before they are referenced.

Add a unit test.
