### PR TITLE
Upgrade apex-parser version to 2.17.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -77,7 +77,7 @@ maven_install(
         "com.google.guava:guava:31.1-jre",
         "com.google.flogger:flogger-system-backend:0.7.4",
         "junit:junit:4.13.2",
-        "com.github.nawforce:apex-parser:2.16.0",
+        "com.github.nawforce:apex-parser:2.17.0",
         "com.google.truth:truth:1.1.3",
         "com.google.code.gson:gson:2.9.0",
         "org.jetbrains.kotlin:kotlin-reflect:1.7.0",

--- a/src/main/java/com/google/summit/ast/statement/DmlStatement.kt
+++ b/src/main/java/com/google/summit/ast/statement/DmlStatement.kt
@@ -25,52 +25,67 @@ import com.google.summit.ast.expression.Expression
  * An outer and a base class for any kind of DML statement.
  *
  * @property value the DML operand
+ * @property access the database operation access mode
  * @param loc the location in the source file
  */
-sealed class DmlStatement(val value: Expression, loc: SourceLocation) : Statement(loc) {
+sealed class DmlStatement(val value: Expression, val access: AccessLevel?, loc: SourceLocation) :
+    Statement(loc) {
   override fun getChildren(): List<Node> = listOfNotNull(value)
 
   /**
    * A DML insert statement.
    *
    * @param value the DML operand
+   * @param access the database operation access mode
    * @param loc the location in the source file
    */
-  class Insert(value: Expression, loc: SourceLocation) : DmlStatement(value, loc)
+  class Insert(value: Expression, access: AccessLevel?, loc: SourceLocation) :
+      DmlStatement(value, access, loc)
 
   /**
    * A DML update statement.
    *
    * @param value the DML operand
+   * @param access the database operation access mode
    * @param loc the location in the source file
    */
-  class Update(value: Expression, loc: SourceLocation) : DmlStatement(value, loc)
+  class Update(value: Expression, access: AccessLevel?, loc: SourceLocation) :
+      DmlStatement(value, access, loc)
 
   /**
    * A DML delete statement.
    *
    * @param value the DML operand
+   * @param access the database operation access mode
    * @param loc the location in the source file
    */
-  class Delete(value: Expression, loc: SourceLocation) : DmlStatement(value, loc)
+  class Delete(value: Expression, access: AccessLevel?, loc: SourceLocation) :
+      DmlStatement(value, access, loc)
 
   /**
    * A DML undelete statement.
    *
    * @param value the DML operand
+   * @param access the database operation access mode
    * @param loc the location in the source file
    */
-  class Undelete(value: Expression, loc: SourceLocation) : DmlStatement(value, loc)
+  class Undelete(value: Expression, access: AccessLevel?, loc: SourceLocation) :
+      DmlStatement(value, access, loc)
 
   /**
    * A DML upsert statement.
    *
    * @param value the DML operand
    * @param name the optional field name
+   * @param access the database operation access mode
    * @param loc the location in the source file
    */
-  class Upsert(value: Expression, val name: Identifier?, loc: SourceLocation) :
-    DmlStatement(value, loc) {
+  class Upsert(
+      value: Expression,
+      val name: Identifier?,
+      access: AccessLevel?,
+      loc: SourceLocation
+  ) : DmlStatement(value, access, loc) {
     override fun getChildren(): List<Node> = listOfNotNull(value, name)
   }
 
@@ -79,10 +94,22 @@ sealed class DmlStatement(val value: Expression, loc: SourceLocation) : Statemen
    *
    * @param value the target value to be updated
    * @param from the value to be merged from
+   * @param access the database operation access mode
    * @param loc the location in the source file
    */
-  class Merge(value: Expression, val from: Expression, loc: SourceLocation) :
-    DmlStatement(value, loc) {
+  class Merge(value: Expression, val from: Expression, access: AccessLevel?, loc: SourceLocation) :
+      DmlStatement(value, access, loc) {
     override fun getChildren(): List<Node> = listOfNotNull(value, from)
+  }
+
+  /**
+   * The database operation access level.
+   *
+   * See:
+   * [Enforce User Mode for Database Operations](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_enforce_usermode.htm)
+   */
+  enum class AccessLevel {
+    USER_MODE,
+    SYSTEM_MODE,
   }
 }

--- a/src/main/javatests/com/google/summit/translation/StatementTest.kt
+++ b/src/main/javatests/com/google/summit/translation/StatementTest.kt
@@ -307,6 +307,9 @@ class StatementTest {
 
     assertNotNull(node)
     assertWithMessage("Node should have one child").that(node.getChildren()).hasSize(1)
+    assertWithMessage("Node should have default/unspecified access")
+      .that(node.access)
+      .isNull()
   }
 
   @Test
@@ -387,5 +390,27 @@ class StatementTest {
 
     assertNotNull(node)
     assertWithMessage("Node should have one child").that(node.getChildren()).hasSize(1)
+  }
+
+  @Test
+  fun dmlStatement_translation_withSystemMode() {
+    val root = parseApexStatementInCode("upsert as system obj field;")
+    val node = TranslateHelpers.findFirstNodeOfType<DmlStatement>(root)
+
+    assertNotNull(node)
+    assertWithMessage("Node should have system access")
+      .that(node.access)
+      .isEqualTo(DmlStatement.AccessLevel.SYSTEM_MODE)
+  }
+
+  @Test
+  fun dmlStatement_translation_withUserMode() {
+    val root = parseApexStatementInCode("insert as user obj;")
+    val node = TranslateHelpers.findFirstNodeOfType<DmlStatement>(root)
+
+    assertNotNull(node)
+    assertWithMessage("Node should have user access")
+      .that(node.access)
+      .isEqualTo(DmlStatement.AccessLevel.USER_MODE)
   }
 }


### PR DESCRIPTION
This includes new syntax for user and system modes for both SOQL and DML.