### PR TITLE
Support Decimal Literals

### DIFF
--- a/src/main/java/com/google/summit/ast/expression/LiteralExpression.kt
+++ b/src/main/java/com/google/summit/ast/expression/LiteralExpression.kt
@@ -19,6 +19,7 @@ package com.google.summit.ast.expression
 import com.google.summit.ast.Node
 import com.google.summit.ast.PrintableAsCodeString
 import com.google.summit.ast.SourceLocation
+import java.math.BigDecimal
 
 /**
  * The outer and base class for literal expressions.
@@ -86,6 +87,16 @@ sealed class LiteralExpression(loc: SourceLocation) : Expression(loc), Printable
    * @param loc the location in the source file
    */
   class DoubleVal(val value: Double, loc: SourceLocation) : LiteralExpression(loc) {
+    override fun asCodeString(): String = value.toString()
+  }
+
+  /**
+   * A decimal number literal. This supports arbitrary precision.
+   *
+   * @property value the decimal value
+   * @param loc the location in the source file
+   */
+  class DecimalVal(val value: BigDecimal, loc: SourceLocation) : LiteralExpression(loc) {
     override fun asCodeString(): String = value.toString()
   }
 }

--- a/src/main/java/com/google/summit/translation/Translate.kt
+++ b/src/main/java/com/google/summit/translation/Translate.kt
@@ -89,6 +89,7 @@ import org.antlr.v4.runtime.TokenStream
 import org.antlr.v4.runtime.misc.Interval
 import org.antlr.v4.runtime.tree.ParseTree
 import org.antlr.v4.runtime.tree.SyntaxTree
+import java.math.BigDecimal
 
 /**
  * Translates an Apex parse tree into an abstract syntax tree (AST).
@@ -714,8 +715,15 @@ class Translate(val file: String, private val tokens: TokenStream) : ApexParserB
           // Trim required trailing 'L' character
           LiteralExpression.LongVal(text.replace("[lL]$".toRegex(), "").toLong(), loc)
         ctx.NumberLiteral() != null ->
-          // Trim optional trailing 'D' character
-          LiteralExpression.DoubleVal(text.replace("[dD]$".toRegex(), "").toDouble(), loc)
+          {
+            // optional trailing 'D' character -> Double
+            if (text.endsWith('d', ignoreCase = true)) {
+              // Trim optional trailing 'D' character
+              return LiteralExpression.DoubleVal(text.replace("[dD]$".toRegex(), "").toDouble(), loc)
+            } else {
+              return LiteralExpression.DecimalVal(BigDecimal(text), loc)
+            }
+          }
         // Trim single quotes
         ctx.StringLiteral() != null ->
           LiteralExpression.StringVal(text.removeSurrounding("'", "'"), loc)

--- a/src/main/javatests/com/google/summit/translation/LiteralExpressionTest.kt
+++ b/src/main/javatests/com/google/summit/translation/LiteralExpressionTest.kt
@@ -25,6 +25,7 @@ import kotlin.test.assertNotNull
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
+import java.math.BigDecimal
 
 @RunWith(JUnit4::class)
 class LiteralExpressionTest {
@@ -82,16 +83,16 @@ class LiteralExpressionTest {
   }
 
   @Test
-  fun number_translation_isDoubleLiteralWithValue() {
+  fun number_translation_isDecimalLiteralWithValue() {
     val code = createCompilationUnitCodeUsingExpression("0.1")
-    val node = TranslateHelpers.parseAndFindFirstNodeOfType<LiteralExpression.DoubleVal>(code)
+    val node = TranslateHelpers.parseAndFindFirstNodeOfType<LiteralExpression.DecimalVal>(code)
 
     assertNotNull(node)
-    assertThat(node.value).isEqualTo(0.1)
+    assertThat(node.value).isEqualTo(BigDecimal("0.1"))
   }
 
   @Test
-  fun d_suffix_is_tolerated() {
+  fun number_translation_isDoubleLiteralWithValue() {
     val code = createCompilationUnitCodeUsingExpression("100.0D")
     val node = TranslateHelpers.parseAndFindFirstNodeOfType<LiteralExpression.DoubleVal>(code)
 


### PR DESCRIPTION
Apex actually differs between double and decimal literals:

https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/langCon_apex_primitives.htm

This PR adds support for decimal literals, as this is needed by PMD (see https://github.com/pmd/pmd/pull/4806#discussion_r1466399873 and https://github.com/pmd/pmd/issues/3766)

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR