### PR TITLE
Support null coalescing operator (Apex 60)

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -28,7 +28,7 @@ kt_jvm_library(
     deps = [
         "@maven//:com_google_guava_guava",
         "@maven//:com_google_flogger_flogger_system_backend",
-        "@maven//:com_github_nawforce_apex_parser",
+        "@maven//:io_github_apex_dev_tools_apex_parser",
         "@maven//:com_google_flogger_flogger",
         "@maven//:org_danilopianini_gson_extras",
         "@maven//:org_apache_commons_commons_lang3",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is not an official Google product.
 ## Dependencies
 
 This is built on top of the
-[apex-parser](https://github.com/nawforce/apex-parser) Apex parser, which is a
+[apex-parser](https://github.com/apex-dev-tools/apex-parser) Apex parser, which is a
 compiled [ANTLR4](https://github.com/antlr/antlr4) grammar.
 
 All dependencies are downloaded and managed through the build system.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This software is built using [bazel](https://bazel.build/).
 
 ```
 $ bazel build ...
+$ bazel test ...
 ```
 
 It is tested and working with the version listed in the `.bazelversion` file.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -77,7 +77,7 @@ maven_install(
         "com.google.guava:guava:31.1-jre",
         "com.google.flogger:flogger-system-backend:0.7.4",
         "junit:junit:4.13.2",
-        "com.github.nawforce:apex-parser:2.17.0",
+        "io.github.apex-dev-tools:apex-parser:3.6.0",
         "com.google.truth:truth:1.1.3",
         "com.google.code.gson:gson:2.9.0",
         "org.jetbrains.kotlin:kotlin-reflect:1.7.0",

--- a/src/main/java/com/google/summit/BUILD
+++ b/src/main/java/com/google/summit/BUILD
@@ -19,7 +19,7 @@ kt_jvm_library(
         "//src/main/java/com/google/summit/ast",
         "//src/main/java/com/google/summit/symbols",
         "//src/main/java/com/google/summit/translation",
-        "@maven//:com_github_nawforce_apex_parser",
+        "@maven//:io_github_apex_dev_tools_apex_parser",
         "@maven//:com_google_flogger_flogger",
         "@maven//:com_google_guava_guava",
     ],

--- a/src/main/java/com/google/summit/ast/expression/BinaryExpression.kt
+++ b/src/main/java/com/google/summit/ast/expression/BinaryExpression.kt
@@ -65,6 +65,8 @@ class BinaryExpression(
     BITWISE_XOR,
     LOGICAL_AND,
     LOGICAL_OR,
+    /** https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/langCon_apex_NullCoalescingOperator.htm */
+    NULL_COALESCING,
   }
 
   /** Constructs an expression from a string representation of the operator. */
@@ -109,6 +111,7 @@ class BinaryExpression(
         "^" -> Operator.BITWISE_XOR
         "&&" -> Operator.LOGICAL_AND
         "||" -> Operator.LOGICAL_OR
+        "??" -> Operator.NULL_COALESCING
         else -> throw IllegalArgumentException("Unknown operator '$str'")
       }
 
@@ -144,6 +147,7 @@ class BinaryExpression(
         Operator.BITWISE_XOR -> "^"
         Operator.LOGICAL_AND -> "&&"
         Operator.LOGICAL_OR -> "||"
+        Operator.NULL_COALESCING -> "??"
       }
   }
 }

--- a/src/main/java/com/google/summit/ast/statement/LoopStatement.kt
+++ b/src/main/java/com/google/summit/ast/statement/LoopStatement.kt
@@ -87,7 +87,7 @@ class WhileLoopStatement(val condition: Expression, body: Statement, loc: Source
  * @param body the statement being looped
  * @param loc the location in the source file
  */
-class DoWhileLoopStatement(val condition: Expression, body: Statement, loc: SourceLocation) :
+class DoWhileLoopStatement(val condition: Expression, body: CompoundStatement, loc: SourceLocation) :
   LoopStatement(body, loc) {
   override fun getChildren(): List<Node> = listOf(condition, body)
 }

--- a/src/main/java/com/google/summit/translation/BUILD
+++ b/src/main/java/com/google/summit/translation/BUILD
@@ -15,7 +15,7 @@ kt_jvm_library(
     srcs = [":sources"],
     deps = [
         "//src/main/java/com/google/summit/ast",
-        "@maven//:com_github_nawforce_apex_parser",
+        "@maven//:io_github_apex_dev_tools_apex_parser",
         "@maven//:com_google_flogger_flogger",
     ],
 )

--- a/src/main/java/com/google/summit/translation/Translate.kt
+++ b/src/main/java/com/google/summit/translation/Translate.kt
@@ -1755,7 +1755,7 @@ class Translate(val file: String, private val tokens: TokenStream) : ApexParserB
   override fun visitDoWhileStatement(ctx: ApexParser.DoWhileStatementContext): Statement =
     DoWhileLoopStatement(
       condition = visitParExpression(ctx.parExpression()),
-      body = visitStatement(ctx.statement()),
+      body = visitBlock(ctx.block()),
       toSourceLocation(ctx)
     )
 

--- a/src/main/java/com/google/summit/translation/Translate.kt
+++ b/src/main/java/com/google/summit/translation/Translate.kt
@@ -1302,6 +1302,17 @@ class Translate(val file: String, private val tokens: TokenStream) : ApexParserB
       toSourceLocation(ctx)
     )
 
+  /**
+   * Translates the 'expression#coalExpression' grammar rule and returns an AST [Expression].
+   */
+  override fun visitCoalExpression(ctx: ApexParser.CoalExpressionContext): Expression =
+    BinaryExpression(
+      visitExpression(ctx.expression().first()),
+      BinaryExpression.Operator.NULL_COALESCING,
+      visitExpression(ctx.expression().last()),
+      toSourceLocation(ctx)
+    )
+
   // END EXPRESSION
 
   // BEGIN PRIMARY

--- a/src/main/javatests/com/google/summit/translation/ExpressionTest.kt
+++ b/src/main/javatests/com/google/summit/translation/ExpressionTest.kt
@@ -361,4 +361,12 @@ class ExpressionTest {
       .that(expression)
       .isInstanceOf(VariableExpression::class.java)
   }
+
+  @Test
+  fun nullCoalescing_translates_to_binaryExpression() {
+    val root = parseApexExpressionInCode("leftHand ?? rightHand")
+    val node = TranslateHelpers.findFirstNodeOfType<BinaryExpression>(root)
+
+    assertWithMessage("A `BinaryExpression` node should be created").that(node).isNotNull()
+  }
 }


### PR DESCRIPTION
This adds support for the new null coalescing operator added with Apex 60:

https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/langCon_apex_NullCoalescingOperator.htm

Example:

```java
Integer notNullReturnValue = anInteger ?? 100;
```

This is needed for https://github.com/pmd/pmd/issues/4828

:warning: This depends on #51 - this PR contains the changes from that.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR