### PR TITLE
SummitTool: Interpret relative paths on command line correctly

### DIFF
--- a/src/main/java/com/google/summit/SummitTool.kt
+++ b/src/main/java/com/google/summit/SummitTool.kt
@@ -47,10 +47,17 @@ object SummitTool {
     for (arg in args) {
       logger.atInfo().log("Searching for Apex source at: %s", arg)
 
+      // bazel changes the current working directory...
+      var absolutePath = Paths.get(arg);
+      val workingDirectory = System.getenv("BUILD_WORKING_DIRECTORY")
+      if (!absolutePath.isAbsolute && workingDirectory != null) {
+        absolutePath = Paths.get(workingDirectory).resolve(absolutePath);
+      }
+
       try {
         val stream: Stream<Path> =
           Files.find(
-            Paths.get(arg),
+            absolutePath,
             Integer.MAX_VALUE,
             { path, _ -> SummitAST.isApexSourceFile(path) }
           )


### PR DESCRIPTION
Fixes #49

bazel run actually changes the working directory, so paths on commandline need to be interpreted relative to the BUILD_WORKING_DIRECTORY

See https://bazel.build/docs/user-manual#running-executables


> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR