### PR TITLE
Upgrade apex-parser version to 4.0.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -77,7 +77,7 @@ maven_install(
         "com.google.guava:guava:31.1-jre",
         "com.google.flogger:flogger-system-backend:0.7.4",
         "junit:junit:4.13.2",
-        "io.github.apex-dev-tools:apex-parser:3.6.0",
+        "io.github.apex-dev-tools:apex-parser:4.0.0",
         "com.google.truth:truth:1.1.3",
         "com.google.code.gson:gson:2.9.0",
         "org.jetbrains.kotlin:kotlin-reflect:1.7.0",

--- a/src/main/java/com/google/summit/SummitAST.kt
+++ b/src/main/java/com/google/summit/SummitAST.kt
@@ -19,9 +19,9 @@ package com.google.summit
 import com.google.common.flogger.FluentLogger
 import com.google.summit.ast.CompilationUnit
 import com.google.summit.translation.Translate
-import com.nawforce.apexparser.ApexLexer
-import com.nawforce.apexparser.ApexParser
-import com.nawforce.apexparser.CaseInsensitiveInputStream
+import io.github.apexdevtools.apexparser.ApexLexer
+import io.github.apexdevtools.apexparser.ApexParser
+import io.github.apexdevtools.apexparser.CaseInsensitiveInputStream
 import java.nio.file.Files
 import java.nio.file.Path
 import org.antlr.v4.runtime.BaseErrorListener

--- a/src/main/java/com/google/summit/ast/declaration/TriggerDeclaration.kt
+++ b/src/main/java/com/google/summit/ast/declaration/TriggerDeclaration.kt
@@ -27,14 +27,14 @@ import com.google.summit.ast.statement.CompoundStatement
  * @param id the unqualified name of the trigger
  * @param target the SObject type to watch
  * @param cases a list of operations to watch
- * @param body the code to execute
+ * @param body the declarations and/or code to execute
  * @param loc the location in the source file
  */
 class TriggerDeclaration(
   id: Identifier,
   val target: Identifier,
   val cases: List<TriggerCase>,
-  val body: CompoundStatement,
+  val body: List<Node>,
   loc: SourceLocation
 ) : TypeDeclaration(id, loc) {
 
@@ -50,5 +50,5 @@ class TriggerDeclaration(
     TRIGGER_AFTER_UNDELETE,
   }
 
-  override fun getChildren(): List<Node> = modifiers + listOfNotNull(id, target, body)
+  override fun getChildren(): List<Node> = modifiers + listOfNotNull(id, target) + body
 }

--- a/src/main/javatests/com/google/summit/testing/TranslateHelpers.kt
+++ b/src/main/javatests/com/google/summit/testing/TranslateHelpers.kt
@@ -23,9 +23,9 @@ import com.google.summit.ast.Untranslated
 import com.google.summit.ast.statement.Statement
 import com.google.summit.ast.traversal.DfsWalker
 import com.google.summit.translation.Translate
-import com.nawforce.apexparser.ApexLexer
-import com.nawforce.apexparser.ApexParser
-import com.nawforce.apexparser.CaseInsensitiveInputStream
+import io.github.apexdevtools.apexparser.ApexLexer
+import io.github.apexdevtools.apexparser.ApexParser
+import io.github.apexdevtools.apexparser.CaseInsensitiveInputStream
 import org.antlr.v4.runtime.BaseErrorListener
 import org.antlr.v4.runtime.CharStreams
 import org.antlr.v4.runtime.CommonTokenStream

--- a/src/main/javatests/com/google/summit/translation/CompilationUnitTest.kt
+++ b/src/main/javatests/com/google/summit/translation/CompilationUnitTest.kt
@@ -19,7 +19,9 @@ package com.google.summit.translation
 import com.google.common.truth.Truth.assertThat
 import com.google.common.truth.Truth.assertWithMessage
 import com.google.summit.ast.declaration.EnumDeclaration
+import com.google.summit.ast.declaration.MethodDeclaration
 import com.google.summit.ast.declaration.TriggerDeclaration
+import com.google.summit.ast.statement.Statement
 import com.google.summit.testing.TranslateHelpers
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -65,5 +67,29 @@ class CompilationUnitTest {
         TriggerDeclaration.TriggerCase.TRIGGER_BEFORE_UPDATE,
         TriggerDeclaration.TriggerCase.TRIGGER_AFTER_DELETE
       )
+  }
+
+  @Test
+  fun triggerWithStatement_translatesTo_expectedTree() {
+    val cu =
+      TranslateHelpers.parseAndTranslate(
+        "trigger MyTrigger on MyObject(before update, after delete) { System.debug(''); }"
+      )
+
+    val triggerDecl = cu.typeDeclaration as TriggerDeclaration
+    val statement = triggerDecl.body.first() as Statement
+    assertThat(triggerDecl.body).containsExactly(statement)
+  }
+
+  @Test
+  fun triggerWithDeclaration_translatesTo_expectedTree() {
+    val cu =
+      TranslateHelpers.parseAndTranslate(
+        "trigger MyTrigger on MyObject(before update, after delete) { public void func() {} }"
+      )
+
+    val triggerDecl = cu.typeDeclaration as TriggerDeclaration
+    val methodDeclaration = triggerDecl.body.first() as MethodDeclaration
+    assertThat(triggerDecl.body).containsExactly(methodDeclaration)
   }
 }


### PR DESCRIPTION
This upgrades apex-parser to the new version and adjust to the grammar changes (trigger block)

* https://github.com/apex-dev-tools/apex-parser/releases/tag/v4.0.0

This is not yet available in maven central (https://central.sonatype.com/artifact/io.github.apex-dev-tools/apex-parser/versions), so the build currently fails. I tested it locally.

This upgrade also contains a fix for typeof needed in https://github.com/pmd/pmd/issues/4922 .

Note: For adapting to the trigger block changes, I naively put the body of the trigger in a `List<Node>`. I assume, the order is then the order how it is defined in the source, possibly mixed declarations and statements. The CompoundStatement is gone and with that also the scoping boundary... Not sure, if this is the best approach.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR