### PR TITLE
Support JSON serialization for SummitTool

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,12 @@ files, builds the AST, and prints basic information. It can be executed by
 running:
 
 ```
-$ bazel run :SummitTool [files | directories ...]
+$ bazel run :SummitTool -- [-json] [files | directories ...]
 ```
 
 Any directories will be recursively walked. The tool attempts to compile any
 files with the extension `.cls` or `.trigger`.
+
+If the optional argument `-json` is given, then the AST is serialized additionally
+as json into a file. The file name will be the original Apex source file with
+the extension `.json` added.

--- a/src/main/java/com/google/summit/BUILD
+++ b/src/main/java/com/google/summit/BUILD
@@ -17,6 +17,7 @@ kt_jvm_library(
     ],
     deps = [
         "//src/main/java/com/google/summit/ast",
+        "//src/main/java/com/google/summit/serialization",
         "//src/main/java/com/google/summit/symbols",
         "//src/main/java/com/google/summit/translation",
         "@maven//:io_github_apex_dev_tools_apex_parser",


### PR DESCRIPTION
I noticed, there were tests already for serializing the AST into json. I thought, it would be useful to expose this via the SummitTool.

While testing, I found that syntax errors were logged multiple times: Once by Antlr itself (via the default ConsoleErrorListener), once by SummitAST before throwing ParseException and now by SummitTool, which logs the parse exception. The exception handling of SummitTool has been fixed to continue with the remaining files and not stop at the first unparseable file.


> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
