### PR TITLE
Bump vaticle_bazel_distribution to 8767cde

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,7 +48,7 @@ kt_register_toolchains()
 git_repository(
     name = "vaticle_bazel_distribution",
     remote = "https://github.com/vaticle/bazel-distribution",
-    commit = "e61daa787bc77d97e36df944e7223821cab309ea"
+    commit = "8767cdec452c14274493c576a2955059ff17f2e4"
 )
 
 # Load //common


### PR DESCRIPTION
Changes: https://github.com/vaticle/bazel-distribution/compare/e61daa787bc77d97e36df944e7223821cab309ea...8767cdec452c14274493c576a2955059ff17f2e4

Fixes #57 in the future. It seems 2.2.0 is the only version, that has this problem. The older versions are fine.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR

**Note:**
I noticed one other change: the create jar files in `bazel-bin` are now called `com.google.summit-summit-ast.jar` instead of `com.google.summit:summit-ast.jar` (previously a colon separated groupId from artifactId, now it's a dash).
Not sure, if this affects how you publish it to central...
