### PR TITLE
Bump apex-parser from 4.1.0 to 4.3.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,7 +89,7 @@ maven_install(
         "com.google.guava:guava:33.2.1-jre",
         "com.google.flogger:flogger-system-backend:0.8",
         "junit:junit:4.13.2",
-        "io.github.apex-dev-tools:apex-parser:4.1.0",
+        "io.github.apex-dev-tools:apex-parser:4.3.1",
         "com.google.truth:truth:1.4.2",
         "com.google.code.gson:gson:2.11.0",
         "org.jetbrains.kotlin:kotlin-reflect:2.0.0",

--- a/src/main/java/com/google/summit/ast/Identifier.kt
+++ b/src/main/java/com/google/summit/ast/Identifier.kt
@@ -40,7 +40,4 @@ class Identifier(val string: String, loc: SourceLocation) :
 
   /** Returns the identifier string. */
   override fun asCodeString(): String = string
-
-  /** Creates a copy of the object with the same string and source location. */
-  fun copy(): Identifier = Identifier(string, getSourceLocation())
 }


### PR DESCRIPTION
apex-parser 4.3.1 introduced a small breaking change by fixing the grammar around switch when statements (https://github.com/apex-dev-tools/apex-parser/commit/bd825354db62ba0ca3c60b85e9e5372793d885aa).
This PR removes the workaround added here and directly uses typeRef for the type and id for the identifier.
The helper method "Identifier.copy()" has been removed.


- [x] Tests pass
- [ ] Appropriate changes to README are included in PR