### PR TITLE
Bump apex-parser from 4.3.1 to 4.4.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,7 +89,7 @@ maven_install(
         "com.google.guava:guava:33.2.1-jre",
         "com.google.flogger:flogger-system-backend:0.8",
         "junit:junit:4.13.2",
-        "io.github.apex-dev-tools:apex-parser:4.3.1",
+        "io.github.apex-dev-tools:apex-parser:4.4.0",
         "com.google.truth:truth:1.4.2",
         "com.google.code.gson:gson:2.11.0",
         "org.jetbrains.kotlin:kotlin-reflect:2.0.0",


### PR DESCRIPTION
Just updates apex-parser to the latest version

See https://github.com/apex-dev-tools/apex-parser/releases/tag/v4.4.0 for the changes.

This time, there is nothing special, as we don't parse SOSL/SOQL (yet).

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR